### PR TITLE
New code to handle env file for petal related API keys

### DIFF
--- a/ask_nature_labeled_prep/asknature_labeled_etl_flat_with_functions.py
+++ b/ask_nature_labeled_prep/asknature_labeled_etl_flat_with_functions.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     raw_data_check(df)
 
     # df = filter_by_lit_site(df, 'pubmed.ncbi.nlm.nih.gov')
-    # df = filter_by_lit_site(df, 'rsta.2009.0022')
+    df = filter_by_lit_site(df, 'springer')
 
     # print("filtered data check")
     # raw_data_check(df)

--- a/ask_nature_labeled_prep/get_list_of_papers_for_coding.py
+++ b/ask_nature_labeled_prep/get_list_of_papers_for_coding.py
@@ -1,7 +1,13 @@
+from pathlib import Path
+import argparse
+import os
+import sys
 import pprint
 
 import requests
 import pandas as pd
+
+from dotenv import load_dotenv
 
 def retrieve_airtable_data(table, api_key):
     '''
@@ -38,10 +44,16 @@ def retrieve_airtable_data(table, api_key):
 
 if __name__ == "__main__":
 
-    from dotenv import load_dotenv
-    import os
+    default_path_to_env = Path( Path.home(), '.petal_env')
 
-    load_dotenv('../.env')
+    parser = argparse.ArgumentParser(prog = sys.argv[0],
+                                     description = "get airtable with labeled papers.")
+    parser.add_argument("--env_path", help = "path to .env file containing API keys",
+                        default = default_path_to_env, type = str)
+
+    args = parser.parse_args()
+
+    load_dotenv(args.env_path)
 
     AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
 

--- a/ask_nature_labeled_prep/get_paper_info.py
+++ b/ask_nature_labeled_prep/get_paper_info.py
@@ -366,7 +366,7 @@ class PaperInfoOUP(PaperInfo):
         return pdf_url
 
     def time_delay(self):
-        time.sleep(random.randint(5, 10))
+        time.sleep(random.randint(20, 40))
 
 class PaperInfoScienceDirect(PaperInfo):
     def get_title(self):

--- a/ask_nature_labeled_prep/retrieve_airtable.py
+++ b/ask_nature_labeled_prep/retrieve_airtable.py
@@ -1,6 +1,12 @@
+from pathlib import Path
+import argparse
+import os
+import sys
+
 import requests
 import pandas as pd
 
+from dotenv import load_dotenv
 
 def retrieve_airtable_data(table, api_key):
     '''
@@ -36,10 +42,16 @@ def retrieve_airtable_data(table, api_key):
     return df
 #
 if __name__ == "__main__":
-    from dotenv import load_dotenv
-    import os
+    default_path_to_env = Path( Path.home(), '.petal_env')
 
-    load_dotenv('../.env')
+    parser = argparse.ArgumentParser(prog = sys.argv[0],
+                                     description = "get airtable with labeled papers.")
+    parser.add_argument("--env_path", help = "path to .env file containing API keys",
+                        default = default_path_to_env, type = str)
+
+    args = parser.parse_args()
+
+    load_dotenv(args.env_path)
 
     AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
     table = 'Colleen%20and%20Alex'


### PR DESCRIPTION
By default it looks in ~/.petal_env but there is a command line option to override that